### PR TITLE
Memory runoff limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ profanity.censor('jerkk off')
 
 2. Any word in [wordlist](https://github.com/snguyenthanh/better_profanity/blob/master/better_profanity/profanity_wordlist.txt) that have non-space separators cannot be recognised, such as `s & m`, and therefore, it won't be filtered out. This problem was raised in [#5](https://github.com/snguyenthanh/better_profanity/issues/5).
 
+3. Single words with sufficiently many leetspeak variants can consume tens or even hundreds of megabytes of memory. This problem was raised in [#15](https://github.com/snguyenthanh/better_profanity/issues/15). Words with too many variants are ignored altogether to prevent system crashes.
+
 ## Testing
 ```
 $ python tests.py

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -2,7 +2,9 @@
 
 from functools import reduce
 from itertools import product
+import logging
 import operator
+from sys import stderr
 
 from .constants import ALLOWED_CHARACTERS, MAX_PATTERNS
 
@@ -12,6 +14,17 @@ from .utils import (
     any_next_words_form_swear_word,
     get_complete_path_of_file,
 )
+
+logger = logging.getLogger("better_profanity")
+logger.setLevel(logging.WARNING)
+handler = logging.StreamHandler(stderr)
+handler.setFormatter(
+    logging.Formatter(
+        fmt="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+)
+logger.addHandler(handler)
 
 
 class Profanity:
@@ -130,10 +143,8 @@ class Profanity:
         # Prevent exponential memory consumption runoff.
         num_patterns = reduce(operator.mul, [len(chars) for chars in combos], 1)
         if num_patterns > MAX_PATTERNS:
-            print(
-                'WARNING: Ignoring "{word}" for having too many variants'.format(
-                    word=word
-                )
+            logger.warning(
+                'Ignoring "{word}" for having too many variants'.format(word=word)
             )
             return ()
 

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -14,7 +14,8 @@ from .utils import (
 )
 
 # Maximum number of patterns that can be generated for a word.
-MAX_PATTERNS = 4_000_000
+MAX_PATTERNS = 4000000
+
 
 class Profanity:
     def __init__(self):
@@ -28,7 +29,7 @@ class Profanity:
             "l": ("l", "1"),
             "e": ("e", "*", "3"),
             "s": ("s", "$", "5"),
-            "t": ("t", "7",),
+            "t": ("t", "7"),
         }
         self.MAX_NUMBER_COMBINATIONS = 1
         self.ALLOWED_CHARACTERS = ALLOWED_CHARACTERS
@@ -121,8 +122,8 @@ class Profanity:
 
     def _generate_patterns_from_word(self, word):
         """
-        Return all patterns can be generated from the word. Returns an empty tuple if the word
-        has too many variants.
+        Return all patterns can be generated from the word. Returns an empty tuple if
+        the word has too many variants.
         """
         combos = [
             (char,) if char not in self.CHARS_MAPPING else self.CHARS_MAPPING[char]
@@ -132,7 +133,11 @@ class Profanity:
         # Prevent exponential memory consumption runoff.
         num_patterns = reduce(operator.mul, [len(chars) for chars in combos], 1)
         if num_patterns > MAX_PATTERNS:
-            print('WARNING: Ignoring "{word}" for having too many variants'.format(word=word))
+            print(
+                'WARNING: Ignoring "{word}" for having too many variants'.format(
+                    word=word
+                )
+            )
             return ()
 
         return ("".join(pattern) for pattern in product(*combos))

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -4,7 +4,7 @@ from functools import reduce
 from itertools import product
 import operator
 
-from .constants import ALLOWED_CHARACTERS
+from .constants import ALLOWED_CHARACTERS, MAX_PATTERNS
 
 from .utils import (
     read_wordlist,
@@ -12,9 +12,6 @@ from .utils import (
     any_next_words_form_swear_word,
     get_complete_path_of_file,
 )
-
-# Maximum number of patterns that can be generated for a word.
-MAX_PATTERNS = 4000000
 
 
 class Profanity:

--- a/better_profanity/constants.py
+++ b/better_profanity/constants.py
@@ -11,6 +11,9 @@ ALLOWED_CHARACTERS = set(ascii_letters)
 ALLOWED_CHARACTERS.update(set(digits))
 ALLOWED_CHARACTERS.update({"@", "$", "*", '"', "'"})
 
+# Maximum number of patterns that can be generated for a word.
+MAX_PATTERNS = 4000000
+
 # Pre-load the unicode characters
 with open(get_complete_path_of_file("alphabetic_unicode.json"), "r") as json_file:
     ALLOWED_CHARACTERS.update(load(json_file))


### PR DESCRIPTION
Fail-safe to prevent system crashes caused by exponential memory consumption runoff. Response to issue #15.

Looking for feedback on:
 * Should `MAX_PATTERNS` be moved to `constants.py`?
 * Should we use the `warning` module for the warning on line 135? Note that this prints a traceback.
 * Do we want to increment the version to `0.6.2`?
 * Anything else that comes to mind.