### PR TITLE
Use character-by-character string comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ profanity.censor('jerkk off')
 
 2. Any word in [wordlist](https://github.com/snguyenthanh/better_profanity/blob/master/better_profanity/profanity_wordlist.txt) that have non-space separators cannot be recognised, such as `s & m`, and therefore, it won't be filtered out. This problem was raised in [#5](https://github.com/snguyenthanh/better_profanity/issues/5).
 
-3. Single words with sufficiently many leetspeak variants can consume tens or even hundreds of megabytes of memory. This problem was raised in [#15](https://github.com/snguyenthanh/better_profanity/issues/15). Words with too many variants are ignored altogether to prevent system crashes.
-
 ## Testing
 ```
 $ python tests.py

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ profanity.censor('jerkk off')
 
 2. Any word in [wordlist](https://github.com/snguyenthanh/better_profanity/blob/master/better_profanity/profanity_wordlist.txt) that have non-space separators cannot be recognised, such as `s & m`, and therefore, it won't be filtered out. This problem was raised in [#5](https://github.com/snguyenthanh/better_profanity/issues/5).
 
+3. Single words with sufficiently many leetspeak variants can consume tens or even hundreds of megabytes of memory. This problem was raised in [#15](https://github.com/snguyenthanh/better_profanity/issues/15). Words with too many variants are ignored altogether to prevent system crashes.
+
 ## Testing
 ```
 $ python tests.py

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -2,7 +2,9 @@
 
 from functools import reduce
 from itertools import product
+import logging
 import operator
+from sys import stderr
 
 from .constants import ALLOWED_CHARACTERS, MAX_PATTERNS
 
@@ -12,6 +14,17 @@ from .utils import (
     any_next_words_form_swear_word,
     get_complete_path_of_file,
 )
+
+logger = logging.getLogger("better_profanity")
+logger.setLevel(logging.WARNING)
+handler = logging.StreamHandler(stderr)
+handler.setFormatter(
+    logging.Formatter(
+        fmt="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+)
+logger.addHandler(handler)
 
 
 class Profanity:
@@ -130,10 +143,8 @@ class Profanity:
         # Prevent exponential memory consumption runoff.
         num_patterns = reduce(operator.mul, [len(chars) for chars in combos], 1)
         if num_patterns > MAX_PATTERNS:
-            print(
-                'WARNING: Ignoring "{word}" for having too many variants'.format(
-                    word=word
-                )
+            logger.warning(
+                'Ignoring "{word}" for having too many variants'.format(word=word)
             )
             return ()
 

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -1,30 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from functools import reduce
-from itertools import product
-import logging
-import operator
-from sys import stderr
+from .constants import ALLOWED_CHARACTERS
 
-from .constants import ALLOWED_CHARACTERS, MAX_PATTERNS
 
 from .utils import (
-    read_wordlist,
-    get_replacement_for_swear_word,
     any_next_words_form_swear_word,
     get_complete_path_of_file,
+    get_replacement_for_swear_word,
+    read_wordlist,
 )
-
-logger = logging.getLogger("better_profanity")
-logger.setLevel(logging.WARNING)
-handler = logging.StreamHandler(stderr)
-handler.setFormatter(
-    logging.Formatter(
-        fmt="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-)
-logger.addHandler(handler)
+from .varying_string import VaryingString
 
 
 class Profanity:
@@ -77,8 +62,8 @@ class Profanity:
             raise TypeError(
                 "Function 'add_censor_words' only accepts list, tuple or set."
             )
-
-        self.CENSOR_WORDSET.update(custom_words)
+        for w in custom_words:
+            self.CENSOR_WORDSET.append(VaryingString(w, char_map=self.CHARS_MAPPING))
 
     def contains_profanity(self, text):
         """Return True if  the input text has any swear words."""
@@ -106,7 +91,8 @@ class Profanity:
 
         # Populate the words into an internal wordset
         whitelist_words = set(whitelist_words)
-        all_censor_words = set()
+        all_censor_words = []
+        # TODO: Prevent identical words from being added twice.
         for word in words:
             # All words in CENSOR_WORDSET must be in lowercase
             word = word.lower()
@@ -118,7 +104,7 @@ class Profanity:
             if num_of_non_allowed_chars > self.MAX_NUMBER_COMBINATIONS:
                 self.MAX_NUMBER_COMBINATIONS = num_of_non_allowed_chars
 
-            all_censor_words.update(set(self._generate_patterns_from_word(word)))
+            all_censor_words.append(VaryingString(word, char_map=self.CHARS_MAPPING))
 
         # The default wordlist takes ~5MB+ of memory
         self.CENSOR_WORDSET = all_censor_words
@@ -129,26 +115,6 @@ class Profanity:
             if char not in self.ALLOWED_CHARACTERS:
                 count += 1
         return count
-
-    def _generate_patterns_from_word(self, word):
-        """
-        Return all patterns can be generated from the word. Returns an empty tuple if
-        the word has too many variants.
-        """
-        combos = [
-            (char,) if char not in self.CHARS_MAPPING else self.CHARS_MAPPING[char]
-            for char in iter(word)
-        ]
-
-        # Prevent exponential memory consumption runoff.
-        num_patterns = reduce(operator.mul, [len(chars) for chars in combos], 1)
-        if num_patterns > MAX_PATTERNS:
-            logger.warning(
-                'Ignoring "{word}" for having too many variants'.format(word=word)
-            )
-            return ()
-
-        return ("".join(pattern) for pattern in product(*combos))
 
     def _update_next_words_indices(self, text, words_indices, start_idx):
         """Return a list of next words_indices after the input index."""

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -14,7 +14,8 @@ from .utils import (
 )
 
 # Maximum number of patterns that can be generated for a word.
-MAX_PATTERNS = 4_000_000
+MAX_PATTERNS = 4000000
+
 
 class Profanity:
     def __init__(self):
@@ -28,7 +29,7 @@ class Profanity:
             "l": ("l", "1"),
             "e": ("e", "*", "3"),
             "s": ("s", "$", "5"),
-            "t": ("t", "7",),
+            "t": ("t", "7"),
         }
         self.MAX_NUMBER_COMBINATIONS = 1
         self.ALLOWED_CHARACTERS = ALLOWED_CHARACTERS
@@ -121,8 +122,8 @@ class Profanity:
 
     def _generate_patterns_from_word(self, word):
         """
-        Return all patterns can be generated from the word. Returns an empty tuple if the word
-        has too many variants.
+        Return all patterns can be generated from the word. Returns an empty tuple if
+        the word has too many variants.
         """
         combos = [
             (char,) if char not in self.CHARS_MAPPING else self.CHARS_MAPPING[char]
@@ -132,7 +133,11 @@ class Profanity:
         # Prevent exponential memory consumption runoff.
         num_patterns = reduce(operator.mul, [len(chars) for chars in combos], 1)
         if num_patterns > MAX_PATTERNS:
-            print('WARNING: Ignoring "{word}" for having too many variants'.format(word=word))
+            print(
+                'WARNING: Ignoring "{word}" for having too many variants'.format(
+                    word=word
+                )
+            )
             return ()
 
         return ("".join(pattern) for pattern in product(*combos))

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from collections.abc import Iterable
+
 from .constants import ALLOWED_CHARACTERS
-
-
 from .utils import (
     any_next_words_form_swear_word,
     get_complete_path_of_file,
@@ -13,8 +13,23 @@ from .varying_string import VaryingString
 
 
 class Profanity:
-    def __init__(self):
-        self.CENSOR_WORDSET = set()
+    def __init__(self, words=None):
+        """
+        Args:
+            words (Iterable/str): Collection of words or file path for a list of
+                words to censor. `None` to use the default word list.
+
+        Raises:
+            TypeError: If `words` is not a valid type.
+            FileNotFoundError: If `words` is a `str` and is not a valid file path.
+        """
+        if (
+            words is not None
+            and not isinstance(words, str)
+            and not isinstance(words, Iterable)
+        ):
+            raise TypeError("words must be of type str, list, or None")
+        self.CENSOR_WORDSET = []
         self.CHARS_MAPPING = {
             "a": ("a", "@", "*", "4"),
             "i": ("i", "*", "l", "1"),
@@ -31,7 +46,10 @@ class Profanity:
         self._default_wordlist_filename = get_complete_path_of_file(
             "profanity_wordlist.txt"
         )
-        self.load_censor_words()
+        if type(words) == str:
+            self.load_censor_words_from_file(words)
+        else:
+            self.load_censor_words(custom_words=words)
 
     ## PUBLIC ##
 
@@ -92,8 +110,7 @@ class Profanity:
         # Populate the words into an internal wordset
         whitelist_words = set(whitelist_words)
         all_censor_words = []
-        # TODO: Prevent identical words from being added twice.
-        for word in words:
+        for word in set(words):
             # All words in CENSOR_WORDSET must be in lowercase
             word = word.lower()
 

--- a/better_profanity/better_profanity.py
+++ b/better_profanity/better_profanity.py
@@ -4,7 +4,7 @@ from functools import reduce
 from itertools import product
 import operator
 
-from .constants import ALLOWED_CHARACTERS
+from .constants import ALLOWED_CHARACTERS, MAX_PATTERNS
 
 from .utils import (
     read_wordlist,
@@ -12,9 +12,6 @@ from .utils import (
     any_next_words_form_swear_word,
     get_complete_path_of_file,
 )
-
-# Maximum number of patterns that can be generated for a word.
-MAX_PATTERNS = 4000000
 
 
 class Profanity:

--- a/better_profanity/constants.py
+++ b/better_profanity/constants.py
@@ -6,13 +6,9 @@ from string import ascii_letters, digits
 
 from .utils import get_complete_path_of_file
 
-
 ALLOWED_CHARACTERS = set(ascii_letters)
 ALLOWED_CHARACTERS.update(set(digits))
 ALLOWED_CHARACTERS.update({"@", "$", "*", '"', "'"})
-
-# Maximum number of patterns that can be generated for a word.
-MAX_PATTERNS = 4000000
 
 # Pre-load the unicode characters
 with open(get_complete_path_of_file("alphabetic_unicode.json"), "r") as json_file:

--- a/better_profanity/constants.py
+++ b/better_profanity/constants.py
@@ -11,6 +11,9 @@ ALLOWED_CHARACTERS = set(ascii_letters)
 ALLOWED_CHARACTERS.update(set(digits))
 ALLOWED_CHARACTERS.update({"@", "$", "*", '"', "'"})
 
+# Maximum number of patterns that can be generated for a word.
+MAX_PATTERNS = 4000000
+
 # Pre-load the unicode characters
 with open(get_complete_path_of_file("alphabetic_unicode.json"), "r") as json_file:
     ALLOWED_CHARACTERS.update(load(json_file))

--- a/better_profanity/utils.py
+++ b/better_profanity/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 import os.path
 
 

--- a/better_profanity/varying_string.py
+++ b/better_profanity/varying_string.py
@@ -1,18 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from itertools import product
-
 
 class VaryingString:
     """Represents a string with varying character representations."""
-
-    @staticmethod
-    def _create_variants(combos):
-        """
-        Args:
-            combos (list): List of lists of character.
-        """
-        return tuple("".join(pattern) for pattern in product(*combos))
 
     def __init__(self, string, char_map={}, variant_thres=10000):
         """

--- a/better_profanity/varying_string.py
+++ b/better_profanity/varying_string.py
@@ -4,12 +4,11 @@
 class VaryingString:
     """Represents a string with varying character representations."""
 
-    def __init__(self, string, char_map={}, variant_thres=10000):
+    def __init__(self, string, char_map={}):
         """
         Args:
             string (str): String to generate variants of.
             char_mappings (dict): Maps characters to substitute characters.
-            variant_thres (int): Maximum number of variants to store in a batch.
         """
         self._original = string
 

--- a/better_profanity/varying_string.py
+++ b/better_profanity/varying_string.py
@@ -22,48 +22,25 @@ class VaryingString:
             variant_thres (int): Maximum number of variants to store in a batch.
         """
         self._original = string
-        self._sliced_variants = []
-        slice_combos = []
-        num_slice_variants = 1
-        for i, char in enumerate(iter(string)):
-            if char in char_map:
-                chars = char_map[char]
-                num_slice_variants *= len(chars)
-                if num_slice_variants > variant_thres:
-                    # Finalize slice.
-                    variants = VaryingString._create_variants(slice_combos)
-                    self._sliced_variants.append(variants)
 
-                    # Move to a new slice.
-                    slice_combos = [chars]
-                    num_slice_variants = 1
-                else:
-                    slice_combos.append(chars)
-            else:
-                slice_combos.append((char,))
-        # Finalize final slice.
-        variants = VaryingString._create_variants(slice_combos)
-        self._sliced_variants.append(variants)
         # There is not necessarily a single length for all of this string's variants.
         # Some character substitutions may include more than one character or empty
         # substitutions.
         self._min_len = 0
         self._max_len = 0
-        for slices in self._sliced_variants:
-            slice_min = None
-            slice_max = None
-            for s in slices:
-                ls = len(s)
-                if slice_min is None:
-                    slice_min = ls
-                    slice_max = ls
-                else:
-                    if ls < slice_min:
-                        slice_min = ls
-                    if ls > slice_max:
-                        slice_max = ls
-            self._min_len += slice_min
-            self._max_len += slice_max
+
+        # Create list of all possible character combinations.
+        self._char_combos = []
+        for char in self._original:
+            if char in char_map:
+                self._char_combos.append(char_map[char])
+                lens = [len(c) for c in char_map[char]]
+                self._min_len += min(lens)
+                self._max_len += max(lens)
+            else:
+                self._char_combos.append((char,))
+                self._min_len += 1
+                self._max_len += 1
 
     def __str__(self):
         return self._original
@@ -78,20 +55,24 @@ class VaryingString:
             len_other = len(other)
             if len_other < self._min_len or len_other > self._max_len:
                 return False
-            other_slice = other
-            for var_slice in self._sliced_variants:
-                match_found = False
-                for variant in var_slice:
-                    len_var = len(variant)
-                    if len(other_slice) >= len_var:
-                        if variant == other_slice[:len_var]:
-                            other_slice = other_slice[len_var:]
-                            match_found = True
-                if not match_found:
+            # We use a list of slices instead of a single slices to account for
+            # character substitutions that contain multiple characters.
+            slices = [other]
+            for chars in self._char_combos:
+                new_slices = []
+                for char in chars:
+                    if not char:
+                        new_slices.extend(slices)
+                    len_char = len(char)
+                    for sl in slices:
+                        if sl[:len_char] == char:
+                            new_slices.append(sl[len_char:])
+                if len(new_slices) == 0:
                     return False
-            if other_slice:
-                return False
-            else:
-                return True
+                slices = new_slices
+            for sl in slices:
+                if len(sl) == 0:
+                    return True
+            return False
         else:
             return False

--- a/better_profanity/varying_string.py
+++ b/better_profanity/varying_string.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+from itertools import product
+
+
+class VaryingString:
+    """Represents a string with varying character representations."""
+
+    @staticmethod
+    def _create_variants(combos):
+        """
+        Args:
+            combos (list): List of lists of character.
+        """
+        return tuple("".join(pattern) for pattern in product(*combos))
+
+    def __init__(self, string, char_map={}, variant_thres=10000):
+        """
+        Args:
+            string (str): String to generate variants of.
+            char_mappings (dict): Maps characters to substitute characters.
+            variant_thres (int): Maximum number of variants to store in a batch.
+        """
+        self._original = string
+        self._sliced_variants = []
+        slice_combos = []
+        num_slice_variants = 1
+        for i, char in enumerate(iter(string)):
+            if char in char_map:
+                chars = char_map[char]
+                num_slice_variants *= len(chars)
+                if num_slice_variants > variant_thres:
+                    # Finalize slice.
+                    variants = VaryingString._create_variants(slice_combos)
+                    self._sliced_variants.append(variants)
+
+                    # Move to a new slice.
+                    slice_combos = [chars]
+                    num_slice_variants = 1
+                else:
+                    slice_combos.append(chars)
+            else:
+                slice_combos.append((char,))
+        # Finalize final slice.
+        variants = VaryingString._create_variants(slice_combos)
+        self._sliced_variants.append(variants)
+        # There is not necessarily a single length for all of this string's variants.
+        # Some character substitutions may include more than one character or empty
+        # substitutions.
+        self._min_len = 0
+        self._max_len = 0
+        for slices in self._sliced_variants:
+            slice_min = None
+            slice_max = None
+            for s in slices:
+                ls = len(s)
+                if slice_min is None:
+                    slice_min = ls
+                    slice_max = ls
+                else:
+                    if ls < slice_min:
+                        slice_min = ls
+                    if ls > slice_max:
+                        slice_max = ls
+            self._min_len += slice_min
+            self._max_len += slice_max
+
+    def __str__(self):
+        return self._original
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        elif other.__class__ == VaryingString:
+            # We have no use case for this yet.
+            raise NotImplementedError
+        elif other.__class__ == str:
+            len_other = len(other)
+            if len_other < self._min_len or len_other > self._max_len:
+                return False
+            other_slice = other
+            for var_slice in self._sliced_variants:
+                match_found = False
+                for variant in var_slice:
+                    len_var = len(variant)
+                    if len(other_slice) >= len_var:
+                        if variant == other_slice[:len_var]:
+                            other_slice = other_slice[len_var:]
+                            match_found = True
+                if not match_found:
+                    return False
+            if other_slice:
+                return False
+            else:
+                return True
+        else:
+            return False

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from better_profanity import profanity
+from better_profanity import profanity, Profanity
 
 
 class ProfanityTest(unittest.TestCase):
@@ -107,6 +107,18 @@ class ProfanityTest(unittest.TestCase):
         profanity.add_censor_words(["supremacia ariana"])
         self.assertEqual(profanity.censor(bad_text), censored_text)
 
+    def test_init_with_list(self):
+        custom_badwords = ["happy", "jolly", "merry"]
+        Profanity(custom_badwords)
+        Profanity(set(custom_badwords))
+        Profanity(tuple(custom_badwords))
+
+    def test_init_with_bad_type(self):
+        with self.assertRaises(TypeError):
+            Profanity(123)
+        with self.assertRaises(TypeError):
+            Profanity(False)
+
 
 class ProfanityUnicodeTestRussian(unittest.TestCase):
     def setUp(self):
@@ -188,6 +200,10 @@ class ProfanityFileTest(unittest.TestCase):
     def test_read_wordlist_not_found(self):
         with self.assertRaises(FileNotFoundError):
             profanity.load_censor_words_from_file("not_found_file.txt")
+
+    def test_init_wordlist_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            Profanity("not_found_file.txt")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Comparing strings character-by-character instead of as full string is more computationally and memory efficient. Here is a run-time comparison for the unit tests (in seconds):
| Version      | 3.4    | 3.5    | 3.6    | 3.7    | 3.8    | PyPy3  |
|--------------|--------|--------|--------|--------|--------|--------|
| Original     | 2.5894 | 2.8381 | 2.2764 | 2.3851 | 2.3346 | 3.3415 |
| Char-by-char | 0.2646 | 0.2848 | 0.2064 | 0.2097 | 0.2122 | 0.3304 |


And here is the memory consumption comparison for several word sets (in Mb):
| Method       | default word list | [YouTube demonetized words](https://docs.google.com/spreadsheets/d/1ozg1Cnm6SdtM4M5rATkANAi07xAzYWaKL7HKxyvoHzk/edit#gid=674179785) | [Google 10000](https://github.com/first20hours/google-10000-english) |
|--------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
| Original   | 54.3                   | ...                                                                                                                                      | 1555.1                                                               |
| Char-by-char | 14.5                   | 15.0                                                                                                                                     | 19.7                                                                 |

These changes also include an extra parameter for the `Profanity` constructor that allows for the optional specification of a word list, either as a file path or an iterable. This comes with respective unit tests.

This merge request would close issue #15.