### PR TITLE
Add unit test for checking all default swear words

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,9 @@
 
 import unittest
 
+import better_profanity
 from better_profanity import profanity, Profanity
+import os
 
 
 class ProfanityTest(unittest.TestCase):
@@ -117,6 +119,19 @@ class ProfanityTest(unittest.TestCase):
             Profanity(123)
         with self.assertRaises(TypeError):
             Profanity(False)
+
+    def test_all_default_words(self):
+        """Tests that every word in the default word list is censored"""
+        wordlist_path = os.path.join(
+            better_profanity.__file__, "../profanity_wordlist.txt"
+        )
+        wordlist_path = os.path.abspath(wordlist_path)
+        with open(wordlist_path) as f:
+            for word in f.readlines():
+                word = word.strip()
+                if word:
+                    self.assertEqual(profanity.censor(word)[:4], "****")
+                    self.assertTrue(profanity.contains_profanity(word))
 
 
 class ProfanityUnicodeTestRussian(unittest.TestCase):


### PR DESCRIPTION
Ensures all swear words listed in the default word list are actually detected as profanity. Intended to be used to test issue #21 and prevent its reemergence. **This test will not pass right now.**