### PR TITLE
Remove redundant and incompatible swear words

### DIFF
--- a/better_profanity/profanity_wordlist.txt
+++ b/better_profanity/profanity_wordlist.txt
@@ -1,5 +1,4 @@
 2 girls 1 cup
-4r5e
 anal
 anus
 areole
@@ -8,9 +7,8 @@ arrse
 arse
 arsehole
 aryan
-aSanchez
+asanchez
 ass
-ass-fucker
 assbang
 assbanged
 asses
@@ -20,7 +18,6 @@ assfukka
 asshole
 assmunch
 asswhole
-auto erotic
 autoerotic
 ballsack
 bastard
@@ -36,7 +33,6 @@ bitch
 bitches
 bitchin
 bitching
-blow job
 blowjob
 blowjobs
 blue waffle
@@ -55,7 +51,6 @@ brown showers
 buceta
 bukake
 bukkake
-bull shit
 bullshit
 busty
 butthole
@@ -80,8 +75,6 @@ cocksucking
 cocksucks
 cokmuncher
 coon
-cow girl
-cow girls
 cowgirl
 cowgirls
 crap
@@ -100,7 +93,6 @@ cuntlicker
 cuntlicking
 cunts
 damn
-deep throat
 deepthroat
 dick
 dickhead
@@ -111,20 +103,15 @@ dinks
 dlck
 dog style
 dog-fucker
-doggie style
-doggie-style
 doggiestyle
 doggin
 dogging
-doggy style
-doggy-style
 doggystyle
 dong
 donkeyribber
 doofus
 doosh
 dopey
-douch3
 douche
 douchebag
 douchebags
@@ -154,10 +141,6 @@ erotism
 essohbee
 extacy
 extasy
-f_u_c_k
-f-u-c-k
-f.u.c.k
-f4nny
 facial
 fack
 fag
@@ -220,7 +203,6 @@ fondle
 foobar
 fook
 fooker
-foot job
 footjob
 foreskin
 freex
@@ -228,11 +210,9 @@ frigg
 frigga
 fubar
 fuck
-fuck-ass
-fuck-bitch
-fuck-tard
 fucka
 fuckass
+fuckbitch
 fucked
 fucker
 fuckers
@@ -271,14 +251,10 @@ fukwit
 futanari
 futanary
 fux
-fux0r
-fvck
+fuxor
 fxck
-g-spot
 gae
 gai
-gang bang
-gang-bang
 gangbang
 gangbanged
 gangbangs
@@ -296,8 +272,6 @@ gigolo
 glans
 goatse
 god
-god-dam
-god-damned
 godamn
 godamnit
 goddam
@@ -305,7 +279,6 @@ goddammit
 goddamn
 goddamned
 gokkun
-golden shower
 goldenshower
 gonad
 gonads
@@ -315,14 +288,10 @@ gringo
 gspot
 gtfo
 guido
-h0m0
-h0mo
 hamflap
-hand job
 handjob
 hardcoresex
 hardon
-he11
 hebe
 heeb
 hell
@@ -339,7 +308,6 @@ hoar
 hoare
 hobag
 hoer
-hom0
 homey
 homo
 homoerotic
@@ -366,18 +334,12 @@ hymen
 inbred
 incest
 injun
-j3rk0ff
-jack off
-jack-off
 jackass
 jackhole
 jackoff
 jap
 japs
 jerk
-jerk off
-jerk-off
-jerk0ff
 jerked
 jerkoff
 jism
@@ -421,7 +383,7 @@ l3i+ch
 l3itch
 labia
 lech
-LEN
+len
 leper
 lesbians
 lesbo
@@ -443,19 +405,11 @@ lust
 lusting
 lusty
 m-fucking
-m0f0
-m0fo
-m45terbate
-ma5terb8
-ma5terbate
 mafugly
 mams
 masochist
 massa
-master-bate
 masterb8
-masterbat*
-masterbat3
 masterbate
 masterbating
 masterbation
@@ -469,8 +423,6 @@ menstruate
 menstruation
 meth
 milf
-mo-fo
-mof0
 mofo
 molest
 moolie
@@ -486,7 +438,6 @@ mothafuckin
 mothafucking
 mothafuckings
 mothafucks
-mother fucker
 motherfuck
 motherfucka
 motherfucked
@@ -513,10 +464,6 @@ muther
 mutherfucker
 mutherfucking
 muthrfucking
-n1g
-n1gg
-n1gga
-n1gger
 nad
 nads
 naked
@@ -528,8 +475,6 @@ needthedick
 negro
 nig
 nigg
-nigg3r
-nigg4h
 nigga
 niggah
 niggas
@@ -543,7 +488,6 @@ ninny
 nipple
 nipples
 nob
-nob jokey
 nobhead
 nobjocky
 nobjokey
@@ -570,8 +514,6 @@ orgy
 ovary
 ovum
 ovums
-p.u.s.s.y.
-p0rn
 paddy
 paki
 pantie
@@ -613,7 +555,6 @@ pimp
 pimpis
 pinko
 piss
-piss-off
 pissed
 pisser
 pissers
@@ -663,7 +604,6 @@ queero
 queers
 quicky
 quim
-r-tard
 racy
 rape
 raped
@@ -689,13 +629,6 @@ rum
 rump
 rumprammer
 ruski
-s_h_i_t
-s-h-1-t
-s-h-i-t
-s-o-b
-s.h.i.t.
-s.o.b.
-s0b
 sadism
 sadist
 sandbar
@@ -721,14 +654,11 @@ semen
 sex
 sexual
 sh!+
-sh!t
-sh1t
 shag
 shagger
 shaggin
 shagging
 shamedame
-she male
 shemale
 shi+
 shibari
@@ -776,6 +706,7 @@ smutty
 snatch
 sniper
 snuff
+sob
 sodom
 son-of-a-bitch
 souse
@@ -801,9 +732,6 @@ suck
 sucked
 sucking
 sumofabiatch
-t1t
-t1tt1e5
-t1tties
 tampon
 tard
 tawdry
@@ -818,7 +746,6 @@ testes
 testical
 testicle
 testis
-three some
 threesome
 throating
 thrust
@@ -829,7 +756,6 @@ titfuck
 titi
 tits
 titt
-tittie5
 tittiefucker
 titties
 titty
@@ -846,7 +772,6 @@ trashy
 tubgirl
 turd
 tush
-tw4t
 twat
 twathead
 twats
@@ -860,12 +785,11 @@ urinal
 urine
 uterus
 uzi
-v14gra
-v1gra
 vag
 vagina
 valium
 viagra
+vigra
 virgin
 vixen
 vodka
@@ -873,7 +797,6 @@ vomit
 voyeur
 vulgar
 vulva
-w00se
 wad
 wang
 wank
@@ -888,8 +811,6 @@ weiner
 weirdo
 wench
 wetback
-wh0re
-wh0reface
 whitey
 whiz
 whoar
@@ -907,6 +828,7 @@ willies
 willy
 womb
 woody
+woose
 wop
 wtf
 x-rated2g1c

--- a/better_profanity/profanity_wordlist.txt
+++ b/better_profanity/profanity_wordlist.txt
@@ -379,7 +379,6 @@ kums
 kunilingus
 kwif
 kyke
-l3i+ch
 l3itch
 labia
 lech
@@ -653,14 +652,12 @@ seduce
 semen
 sex
 sexual
-sh!+
 shag
 shagger
 shaggin
 shagging
 shamedame
 shemale
-shi+
 shibari
 shibary
 shit


### PR DESCRIPTION
The removed words are recognized by the censor as variations of other words already in the list.

Some words that were only written in leetspeak were removed and replaced with more generalized words, such as `v1gra` being replaced with `vigra`.