### PR TITLE
Remove support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
     - python: 3.8
       env: TOXENV=black
 
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Inspired from package [profanity](https://github.com/ben174/profanity) of [Ben F
 It supports [modified spellings](https://en.wikipedia.org/wiki/Leet) (such as `p0rn`, `h4NDjob`, `handj0b` and `b*tCh`).
 
 ## Requirements
-This package works with `Python 3.4+` and `PyPy3`.
+This package works with `Python 3.5+` and `PyPy3`.
 
 ## Installation
 ```

--- a/README.md
+++ b/README.md
@@ -14,12 +14,8 @@ Inspired from package [profanity](https://github.com/ben174/profanity) of [Ben F
 It supports [modified spellings](https://en.wikipedia.org/wiki/Leet) (such as `p0rn`, `h4NDjob`, `handj0b` and `b*tCh`).
 
 ## Requirements
-<<<<<<< HEAD
-This package works with `Python 3.5+` and `PyPy3`.
-=======
 
-This package works with `Python 3.4+` and `PyPy3`.
->>>>>>> 3b6fe62f5b97be9884496901f3732489f880c848
+This package works with `Python 3.5+` and `PyPy3`.
 
 ## Installation
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     black
-    py34, py35, py36, py37, py38, pypy3
+    py35, py36, py37, py38, pypy3
 
 skipsdist = True
 skip_missing_interpreters = True
@@ -19,9 +19,8 @@ whitelist_externals = make
                       /bin/bash
 
 basepython =
-		py34: python3.4
-		py35: python3.5
-		py36: python3.6
+    py35: python3.5
+    py36: python3.6
     py37: python3.7
     py38: python3.8
 


### PR DESCRIPTION
Python 3.4 support has been removed in the latest versions of `tox`, [as seen here](https://github.com/tox-dev/tox/pull/1525). 

Attempting to run `tox` 3.20.1 on `better_profanity` outputs the following log for the `py34` tests:

```
ERROR: invocation failed (exit code 1), logfile: <OMITTED>/better_profanity/.tox/py34/log/py34-11.log
=============================== log start ================================
Traceback (most recent call last):
  File "/usr/lib/python3.4/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.4/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pip/__main__.py", line 16, in <module>
    from pip._internal.cli.main import main as _main  # isort:skip # noqa
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pip/_internal/cli/main.py", line 10, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pip/_internal/cli/autocompletion.py", line 9, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pip/_internal/cli/main_parser.py", line 7, in <module>
    from pip._internal.cli import cmdoptions
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pip/_internal/cli/cmdoptions.py", line 24, in <module>
    from pip._internal.exceptions import CommandError
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pip/_internal/exceptions.py", line 10, in <module>
    from pip._vendor.six import iteritems
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pip/_vendor/__init__.py", line 79, in <module>
    vendored("pkg_resources")
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pip/_vendor/__init__.py", line 36, in vendored
    __import__(modulename, globals(), locals(), level=0)
  File "/mnt/linux_storage/joshypoo/Projects/better_profanity/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py", line 92, in <module>
    raise RuntimeError("Python 3.5 or later is required")
RuntimeError: Python 3.5 or later is required

================================ log end =================================
```

The alternative seems to be using an older version of `tox` indefinitely.