### PR TITLE
Add 'f***ots' to profanity wordlist

### DIFF
--- a/better_profanity/profanity_wordlist.txt
+++ b/better_profanity/profanity_wordlist.txt
@@ -150,6 +150,7 @@ fagging
 faggit
 faggitt
 faggot
+faggots
 faggs
 fagot
 fagots


### PR DESCRIPTION
Surprisingly enough to me, profanity wordlist doesn't have the plural form of "f***ot"